### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/continuousintegration.yml
+++ b/.github/workflows/continuousintegration.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions:
+  contents: read
 on: 
     pull_request:
       branches:


### PR DESCRIPTION
Potential fix for [https://github.com/RafaelUtzig/CI-CD/security/code-scanning/1](https://github.com/RafaelUtzig/CI-CD/security/code-scanning/1)

The best way to fix this issue is to explicitly set the minimum required permissions for the GITHUB_TOKEN within the workflow file. This can be done by adding a `permissions` block at the workflow root (applies to all jobs) or at the job level, as appropriate. Since the job in question only checks out code and runs linting, it only needs to read repository content. Therefore, add `permissions: contents: read` to restrict the token's scope.

- Add a `permissions:` block after the workflow name but before the `on:` or `jobs:` blocks.
- Insert the following:
  ```yaml
  permissions:
    contents: read
  ```
- No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
